### PR TITLE
Update Node Exporter version and download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ All needed packages will be installed with this role.
 
 Available variables are listed below, along with default values:
 ```yaml
-prometheus_node_exporter_version: 0.12.0
+prometheus_node_exporter_version: 0.13.0
 
 prometheus_node_exporter_enabled_collectors:
   - conntrack

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-prometheus_node_exporter_version: 0.12.0
+prometheus_node_exporter_version: 0.13.0
 prometheus_node_exporter_release_name: "node_exporter-{{ prometheus_node_exporter_version }}.linux-amd64"
 
 # https://github.com/prometheus/node_exporter#enabled-by-default

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: download prometheus node exporter binary
   get_url:
-    url: "https://github.com/prometheus/node_exporter/releases/download/{{ prometheus_node_exporter_version }}/{{ prometheus_node_exporter_release_name }}.tar.gz"
+    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ prometheus_node_exporter_version }}/{{ prometheus_node_exporter_release_name }}.tar.gz"
     dest: "{{ prometheus_exporters_common_dist_dir }}"
 
 - name: unarchive binary tarball


### PR DESCRIPTION
Правда и 0.12.0 в таком случае не накатится из-за смены URL с версии 0.13.0.

Касается только тех, кто живёт на мастере и установленной переменной `prometheus_node_exporter_version` <= 0.12.0 вместо `defaults`.