### PR TITLE
Fix #4 : url of prometheus/node_exporter change with version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 prometheus_node_exporter_version: 0.12.0
 prometheus_node_exporter_release_name: "node_exporter-{{ prometheus_node_exporter_version }}.linux-amd64"
+url: "{% if prometheus_node_exporter_version | version_compare('0.13.0', '>=') %}https://github.com/prometheus/node_exporter/releases/download/v{{ prometheus_node_exporter_version }}/{{ prometheus_node_exporter_release_name }}.tar.gz{% else %}https://github.com/prometheus/node_exporter/releases/download/{{ prometheus_node_exporter_version }}/{{ prometheus_node_exporter_release_name }}.tar.gz{% endif %}"
 
 # https://github.com/prometheus/node_exporter#enabled-by-default
 prometheus_node_exporter_enabled_collectors:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: download prometheus node exporter binary
   get_url:
-    url: "https://github.com/prometheus/node_exporter/releases/download/{{ prometheus_node_exporter_version }}/{{ prometheus_node_exporter_release_name }}.tar.gz"
+    url: "{{ url }}"
     dest: "{{ prometheus_exporters_common_dist_dir }}"
 
 - name: unarchive binary tarball


### PR DESCRIPTION
it's need to create a new variable as prometheus_node_exporter_version is use in prometheus_node_exporter_release_name