### PR TITLE
Fix #3 : AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems

### DIFF
--- a/templates/etc/systemd/system/prometheus-node-exporter.service.j2
+++ b/templates/etc/systemd/system/prometheus-node-exporter.service.j2
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=root
 Group={{ prometheus_exporters_common_group }}
-ExecStart={{ prometheus_exporters_common_root_dir }}/node_exporter_current/node_exporter -collectors.enabled={{ prometheus_node_exporter_enabled_collectors | join(',') }} {% for flag, flag_value in prometheus_node_exporter_config_flags.iteritems() %}-{{ flag }}={{ flag_value }} {% endfor %}
+ExecStart={{ prometheus_exporters_common_root_dir }}/node_exporter_current/node_exporter -collectors.enabled={{ prometheus_node_exporter_enabled_collectors | join(',') }} {% for flag, flag_value in prometheus_node_exporter_config_flags.items() %}-{{ flag }}={{ flag_value }} {% endfor %}
 
 SyslogIdentifier=prometheus_node_exporter
 Restart=always


### PR DESCRIPTION
Fixing this issue : 
```
TASK [UnderGreen.prometheus-node-exporter : create systemd service unit] *******
Thursday 23 March 2017  16:58:03 +1300 (0:00:00.286)       0:01:10.353 ********
fatal: [images-worker]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"}
```