### PR TITLE
add support for firewalld

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ All needed packages will be installed with this role.
 | prometheus_node_exporter_release_name       | string |                                                                                    | node_exporter-{{ prometheus_node_exporter_version }}.linux-amd64                                                            | Name of the binary that will be downloaed from the   [release](https://github.com/prometheus/node_exporter/releases)  page |
 | prometheus_node_exporter_enabled_collectors | list   | [List of flags](https://github.com/prometheus/node_exporter)                       | conntrack, diskstats, entropy, filefd, filesystem, loadavg,   mdadm, meminfo, netdev, netstat, stat, textfile, time, vmstat | List of enabled collector                                                                                                  |
 | prometheus_node_exporter_config_flags       | dict   |                                                                                    |                                                                                                                             | Dict of key, value options to add to the start command line                                                                |
+| prometheus_node_exporter_firewall           | dict   |                                                                                    |                                                                                                                             | Used if the node is placed behind a firewall. Desactivated by default                                                      |
 
+
+**prometheus_node_exporter_firewall dict:**
+
+| Variable       | Type    | Choices     | Default   | Comment                                                                           |
+|----------------|---------|-------------|-----------|-----------------------------------------------------------------------------------|
+| active         | Boolean | True, False | FALSE     | If True, a firewall rule will be applied to allow an access to the listen_port    |
+| type           | string  | firewalld   | firewalld | Type of firewall process. Only firewalld supported so far                         |
+| listen_port    | int     |             | 9100      | Must be the same as the address set in "web.listen-address"                       |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,12 @@ prometheus_node_exporter_enabled_collectors:
 prometheus_node_exporter_config_flags:
   'web.listen-address': '0.0.0.0:9100'
   'log.level': 'info'
+
+# if the node is behind a firewall
+# active: set to True to open the firewall on the "listen_port"
+# type: only "firewalld" supported so far
+# listen_port: must be the same as the "web.listen-address". By default 9100
+prometheus_node_exporter_firewall:
+  active: False
+  type: firewalld
+  listen_port: 9100

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,3 +10,8 @@
   service:
     name: prometheus-node-exporter
     state: restarted
+
+- name: restart firewalld
+  service:
+    name: firewalld
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,3 +77,25 @@
     name: prometheus-node-exporter
     state: started
     enabled: yes
+
+- name: Create firewalld service
+  template:
+    src: etc/firewalld/services/node-exporter-service.xml
+    dest: /etc/firewalld/services/node-exporter-service.xml
+    owner: root
+    group: root
+    mode: 0644
+  when: prometheus_node_exporter_firewall.active and prometheus_node_exporter_firewall.type == "firewalld"
+  notify: restart firewalld
+
+# restart firewalld immediately to get the new service
+- meta: flush_handlers
+
+- name: Allow the exporter on public interface
+  firewalld:
+    service: node-exporter-service
+    zone: public
+    permanent: true
+    state: enabled
+  when: prometheus_node_exporter_firewall.active and prometheus_node_exporter_firewall.type == "firewalld"
+  notify: restart firewalld

--- a/templates/etc/firewalld/services/node-exporter-service.xml
+++ b/templates/etc/firewalld/services/node-exporter-service.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>node-exporter-service</short>
+  <description>Prometheus Node Exporter</description>
+  <port protocol="tcp" port="{{ prometheus_node_exporter_firewall.listen_port }}"/>
+</service>


### PR DESCRIPTION
Add a support for firewalld.

The variable `type` leave an opened window for futur support like iptables.