### PR TITLE
Fix service auto-start with upstart

### DIFF
--- a/templates/etc/init/prometheus-node-exporter.conf.j2
+++ b/templates/etc/init/prometheus-node-exporter.conf.j2
@@ -1,6 +1,6 @@
 description "Prometheus Node Exporter"
-start on (local-filesystems and net-device-up IFACE!=lo)
-stop on runlevel [016]
+start on (runlevel [345] and started network)
+stop on (runlevel [!345] or stopping network)
 
 respawn
 {% if upstart_version.stdout | replace("init (upstart ", "") |replace(")","") | version_compare('1.4', '>=') %}


### PR DESCRIPTION
Having issues with auto-starting service when upstart is used. More specifically with Amazon AMI images.