### PR TITLE
[FIX] start service fails

### DIFF
--- a/templates/etc/init.d/prometheus-node-exporter.j2
+++ b/templates/etc/init.d/prometheus-node-exporter.j2
@@ -35,9 +35,8 @@ start() {
     #[ -f $config ] || exit 6
     echo -n $"Starting $prog: "
     # if not running, start it up here, usually something like "daemon $exec"
-    daemon {{ prometheus_exporters_common_root_dir }}/node_exporter_current/node_exporter {% for prometheus_node_exporter_collector in prometheus_node_exporter_enabled_collectors %}--collector.{{ prometheus_node_exporter_collector }} {% endfor %} {% for flag, flag_value in prometheus_node_exporter_config_flags.items() %}--{{ flag }}={{ flag_value }} {% endfor %}
-    echo
-    [ $retval -eq 0 ] && touch $lockfile
+    daemon {{ prometheus_exporters_common_root_dir }}/node_exporter_current/node_exporter {% for prometheus_node_exporter_collector in prometheus_node_exporter_enabled_collectors %}--collector.{{ prometheus_node_exporter_collector }} {% endfor %} {% for flag, flag_value in prometheus_node_exporter_config_flags.items() %}--{{ flag }}={{ flag_value }} {% endfor %} &
+    [ $? -eq 0 ] && touch $lockfile
     return $retval
 }
 


### PR DESCRIPTION
Problem:
The `echo` is there for no reason and causes an error.
When removing `echo`, the start service gets stuck because it is no daemonized well.

Error printscreen:
![image](https://user-images.githubusercontent.com/18627927/45235962-2bfb2600-b2e3-11e8-9547-d7fde764981c.png)

OS info:
![image](https://user-images.githubusercontent.com/18627927/45236008-50ef9900-b2e3-11e8-8b39-8ac39e0e2ce6.png)


Solution:
Remove echo, add & to background the init and change the check to $? (last command exit code).

Prove that works:

![image](https://user-images.githubusercontent.com/18627927/45236144-b774b700-b2e3-11e8-86e7-ff499c6090d9.png)





