### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All needed packages will be installed with this role.
 ```yaml
 - hosts: node-exporters
   roles:
-    - role: UnderGreen.prometheus-node-exporter
+    - role: undergreen.prometheus-node-exporter
       prometheus_node_exporter_version: 0.17.0
       prometheus_node_exporter_enabled_collectors:
         - conntrack


### PR DESCRIPTION
This commit is to update the example to run this rule when adding to a
playbook file.

Because when I download from Ansible-galaxy then the name of this role
is "undergreen.prometheus-node-exporter"
instead of "UnderGreen.prometheus-node-exporter".