### PR TITLE
added restartsec and startlimitinterval configurations

### DIFF
--- a/templates/etc/systemd/system/prometheus-node-exporter.service.j2
+++ b/templates/etc/systemd/system/prometheus-node-exporter.service.j2
@@ -1,6 +1,7 @@
 [Unit]
 Description=Prometheus Node Exporter
 After=network.target
+StartLimitInterval=0
 
 [Service]
 Type=simple
@@ -10,6 +11,7 @@ ExecStart={{ prometheus_exporters_common_root_dir }}/node_exporter_current/node_
 
 SyslogIdentifier=prometheus_node_exporter
 Restart=always
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
By default, when you configure Restart=always as we did, systemd gives up restarting your service if it fails to start more than 5 times within a 10 seconds interval. Forever.
There are two [Unit] configuration options responsible for this:
StartLimitBurst=5
StartLimitInterval=10

The simple fix that always works is to set StartLimitInterval=0. This way, systemd will attempt to restart your service forever.
It’s a good idea to set RestartSec to at least 1 second though, to avoid putting too much stress on your server when things start going wrong.

[Source](https://medium.com/@benmorel/creating-a-linux-service-with-systemd-611b5c8b91d6)