### PR TITLE
Use network-online target to avoid potential race

### DIFF
--- a/templates/etc/systemd/system/prometheus-node-exporter.service.j2
+++ b/templates/etc/systemd/system/prometheus-node-exporter.service.j2
@@ -1,6 +1,7 @@
 [Unit]
 Description=Prometheus Node Exporter
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
We encountered some issues with the exporter trying to bind to an IP address (that isn't `127.0.0.1` or `0.0.0.0`), which isn't guaranteed to be available with `network.target`, causing an error to occur and the exporter to not start. This problem can be avoided by waiting for `network-online.target`, which ensures that all configured network interfaces are up and have an IP address assigned.

See https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/ for more details about what `network-online.target` does.