### PR TITLE
Prevent deprecation warning

### DIFF
--- a/templates/etc/init/prometheus-node-exporter.conf.j2
+++ b/templates/etc/init/prometheus-node-exporter.conf.j2
@@ -3,7 +3,7 @@ start on (runlevel [345] and started network)
 stop on (runlevel [!345] or stopping network)
 
 respawn
-{% if upstart_version.stdout | replace("init (upstart ", "") |replace(")","") | version_compare('1.4', '>=') %}
+{% if upstart_version.stdout | replace("init (upstart ", "") |replace(")","") is version('1.4', '>=') %}
 setuid {{ prometheus_exporters_common_user }}
 setgid {{ prometheus_exporters_common_group }}
 {% endif %}


### PR DESCRIPTION
[DEPRECATION WARNING]: Using tests as filters is deprecated.