### PR TITLE
Fix #47 Don't create empty dir in user's home

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: update group and owner for files
   file:
-    path: "{{ prometheus_node_exporter_release_name }}"
+    path: "{{ prometheus_exporters_common_dist_dir }}/{{ prometheus_node_exporter_release_name }}"
     state: directory
     recurse: yes
     owner: "{{ prometheus_exporters_common_user}}"


### PR DESCRIPTION
Fix the path of the Prometheus node exporter directory of the 'update
group and owner for files' task. As a result:
* No empty directory is created in the ansible user's home anymore
* The Prometheus node exporter directory has appropriate owner and group