### PR TITLE
Download node_exporter on the ansible host and push it via ansible to remote hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 # minimum supported version: 0.15
 prometheus_node_exporter_version: 0.18.1
 prometheus_node_exporter_release_name: "node_exporter-{{ prometheus_node_exporter_version }}.linux-amd64"
+prometheus_node_exporter_offline_name: ""
 
 # https://github.com/prometheus/node_exporter#enabled-by-default
 prometheus_node_exporter_enabled_collectors: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@
 # minimum supported version: 0.15
 prometheus_node_exporter_version: 0.18.1
 prometheus_node_exporter_release_name: "node_exporter-{{ prometheus_node_exporter_version }}.linux-amd64"
-prometheus_node_exporter_offline_name: ""
 
 # https://github.com/prometheus/node_exporter#enabled-by-default
 prometheus_node_exporter_enabled_collectors: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,9 @@
 
 - name: download prometheus node exporter binary locally
   local_action:
-    get_url:
-      url: "{{ url }}"
-      dest: "/tmp/{{ prometheus_node_exporter_release_name }}.tar.gz"
+    module: get_url
+    url: "{{ url }}"
+    dest: "/tmp/{{ prometheus_node_exporter_release_name }}.tar.gz"
   
 - name: transfer local node exporter binary
   copy: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,5 +85,5 @@
 - name: ensure prometheus node exporter service is enabled and started
   service:
     name: prometheus-node-exporter
-    state: started
+    state: restarted
     enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,18 @@
 ---
 
-- name: download prometheus node exporter binary
-  get_url:
-    url: "{{ url }}"
+- name: download prometheus node exporter binary locally
+  local_action:
+    get_url:
+      url: "{{ url }}"
+      dest: "/tmp/{{ prometheus_node_exporter_release_name }}.tar.gz"
+  
+- name: transfer local node exporter binary
+  copy: 
+    src: "/tmp/{{ prometheus_node_exporter_release_name }}.tar.gz"
     dest: "{{ prometheus_exporters_common_dist_dir }}/{{ prometheus_node_exporter_release_name }}.tar.gz"
+    owner: "{{ prometheus_exporters_common_user}}"
+    group: "{{ prometheus_exporters_common_group }}"
+    mode: '0755'
 
 - name: unarchive binary tarball
   unarchive:


### PR DESCRIPTION
This PR makes the role download the node_exporter binary on the ansible host (in /tmp) and pushes it via ssh to the remote host. The reason is - older hosts (e.g. CentOS6, without updates) may no longer have SSL cyphers in common with modern servers and can't pull packages through https anymore, and also, for hosts that are isolated from the internet, it's best to get the package on the ansible host.