### PR TITLE
Don't become root when downloading binary

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: download prometheus node exporter binary locally
+  become: no
   local_action:
     module: get_url
     url: "{{ url }}"


### PR DESCRIPTION
I'm surprised no one had problems with this before. I'm using the role against a host which has NOPASSWD in sudoers. And for that certain host I use a different ansible.cfg without local inventory and become_pass not set for localhost. And I have set become: yes for the whole paly. Hence the role fails on downloading binary into /tmp.

```
│ TASK [undergreen.prometheus-node-exporter : download prometheus node exporter binary locally] ***
│ Friday 11 June 2021  18:31:38 +0300 (0:00:01.931)       0:05:28.864 *********** 
│ fatal: [dev-mongo-shard--01.teko.local]: FAILED! => changed=false 
│   module_stderr: |-
│     sudo: a password is required
│   module_stdout: ''
│   msg: |-
│     MODULE FAILURE
│     See stdout/stderr for the exact error
│   rc: 1
```

With the little fix above everything works as intended.