### PR TITLE
debian buster is supported by the role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
   platforms:
   - name: Debian
     versions:
+    - buster
     - jessie
     - wheezy
   - name: Ubuntu


### PR DESCRIPTION
A minor merge request to inform **end user** : debian buster is support by this roles

It's working without any issue :
```
~# cat /etc/debian_version 
10.8
~# curl localhost:9100/metrics
# HELP go_gc_duration_seconds A summary of the GC invocation durations.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 7.5828e-05
go_gc_duration_seconds{quantile="0.25"} 0.000108572
...
```

And the associated systemd logs :
```
prometheus_node_exporter[84731]: time="2021-08-04T14:15:14+02:00" level=info msg=" - vmstat" source="node_exporter.go:104"
...
prometheus_node_exporter[84731]: time="2021-08-04T14:15:14+02:00" level=info msg="Listening on 0.0.0.0:9100" source="node_exporter.go:170"
```